### PR TITLE
Thumb2: Lift MLA/MLS

### DIFF
--- a/thumb2_disasm/il_thumb2.cpp
+++ b/thumb2_disasm/il_thumb2.cpp
@@ -742,6 +742,12 @@ bool GetLowLevelILForThumbInstruction(Architecture* arch, LowLevelILFunction& il
 		il.AddInstruction(WriteArithOperand(il, instr, il.LogicalShiftRight(4, ReadArithOperand(il, instr, 0),
 			ReadArithOperand(il, instr, 1), ifThenBlock ? 0 : IL_FLAGWRITE_ALL)));
 		break;
+	case armv7::ARMV7_MLA:
+		il.AddInstruction(WriteILOperand(il, instr, 0, il.Add(4, ReadILOperand(il, instr, 3), il.Mult(4, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2)))));
+		break;
+	case armv7::ARMV7_MLS:
+		il.AddInstruction(WriteILOperand(il, instr, 0, il.Sub(4, ReadILOperand(il, instr, 3), il.Mult(4, ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2)))));
+		break;
 	case armv7::ARMV7_MOV:
 	case armv7::ARMV7_MOVW:
 		il.AddInstruction(WriteILOperand(il, instr, 0, ReadILOperand(il, instr, 1)));


### PR DESCRIPTION
`MLA{cond} Rd, Rn, Rm, Ra` and `MLS{cond} Rd, Rn, Rm, Ra`

lift to: `Rd = Ra + (Rn * Rm)` and `Rd = Ra - (Rn * Rm)`, respectively.

Note: There is a flag-setting version of MLA documented (MLAS), but the manual gives me the impression that that does not exist in Thumb, or at least not in armv7-m.