### PR TITLE
Thumb2: Lift SBC{S}

### DIFF
--- a/thumb2_disasm/il_thumb2.cpp
+++ b/thumb2_disasm/il_thumb2.cpp
@@ -798,6 +798,18 @@ bool GetLowLevelILForThumbInstruction(Architecture* arch, LowLevelILFunction& il
 		il.AddInstruction(WriteArithOperand(il, instr, il.Sub(4, ReadArithOperand(il, instr, 1),
 			ReadArithOperand(il, instr, 0), ifThenBlock ? 0 : IL_FLAGWRITE_ALL)));
 		break;
+	case armv7::ARMV7_SBC:
+		il.AddInstruction(WriteILOperand(il, instr, 0, il.SubBorrow(4, ReadILOperand(il, instr, 1),
+									       ReadShiftedOperand(il, instr, 2),
+									       il.Not(1, il.Flag(IL_FLAG_C)),
+									       WritesToStatus(instr, ifThenBlock) ? IL_FLAGWRITE_ALL : 0)));
+		break;
+	case armv7::ARMV7_SBCS:
+		il.AddInstruction(WriteILOperand(il, instr, 0, il.SubBorrow(4, ReadILOperand(il, instr, 1),
+									       ReadShiftedOperand(il, instr, 2),
+									       il.Not(1, il.Flag(IL_FLAG_C)),
+									       ifThenBlock ? 0 : IL_FLAGWRITE_ALL)));
+		break;
 	case ARMV7_STM:
 	case ARMV7_STMIA:
 	case ARMV7_STMDB:


### PR DESCRIPTION
`SBCS Rd, Rn, Rm{, <shift>}` and `SBC{cond} Rd, Rn, Rm{, <shift>}`

`Rd = sbb.d(Rn, Rm, not.b(flag:c))` (with optional shift on Rm)