### PR TITLE
Thumb2: Decode ARMv7-M special registers

### DIFF
--- a/thumb2_disasm/spec.cpp
+++ b/thumb2_disasm/spec.cpp
@@ -12892,19 +12892,19 @@ int mrrc_mrrc2(struct decomp_request *req, struct decomp_result *res)
 	return undefined(req, res);
 }
 
-// gen_crc: AC3E2164
+// gen_crc: A720271F
 int mrs(struct decomp_request *req, struct decomp_result *res)
 {
 	int rc = -1;
 
 	res->group = INSN_GROUP_UNKNOWN;
 	/* Encoding T1 */
-	/* pattern="11110,0,1111,1,R.1,(1)(1)(1)(1),10,(0),0,Rd.4,(0)(0)(0)(0)(0)(0)(0)(0)" width=32 stringency=28 */
+	/* pattern="11110,0,1111,1,R.1,(1)(1)(1)(1),10,(0),0,Rd.4,SYSm.8" width=32 stringency=20 */
 	{
 		uint32_t instr = req->instr_word32;
 		if(((instr & 0xFFE0D000)==0xF3E08000)) {
 			res->instrSize = 32;
-			if(!((instr & 0xF20FF)==0xF0000)) {
+			if(!((instr & 0xF2000)==0xF0000)) {
 				res->flags |= FLAG_UNPREDICTABLE;
 			}
 			if(!(req->arch & ARCH_ARMv6T2) && !(req->arch & ARCH_ARMv7)) {
@@ -12918,6 +12918,9 @@ int mrs(struct decomp_request *req, struct decomp_result *res)
 			res->fields[FIELD_Rd] = (instr & 0xF00)>>8;
 			res->fields_mask[FIELD_Rd >> 6] |= 1LL << (FIELD_Rd & 63);
 			char Rd_width = 4;
+			res->fields[FIELD_SYSm] = instr & 0xFF;
+			res->fields_mask[FIELD_SYSm >> 6] |= 1LL << (FIELD_SYSm & 63);
+			char SYSm_width = 8;
 
 			static const instruction_format instr_formats[] =
 			{
@@ -12956,19 +12959,19 @@ int mrs(struct decomp_request *req, struct decomp_result *res)
 	return undefined(req, res);
 }
 
-// gen_crc: 38891CAD
+// gen_crc: 7885C1A4
 int msr_reg_app(struct decomp_request *req, struct decomp_result *res)
 {
 	int rc = -1;
 
 	res->group = INSN_GROUP_UNKNOWN;
 	/* Encoding T1 */
-	/* pattern="11110,0,1110,0,0,Rn.4,10,(0),0,mask.2,00,(0)(0)(0)(0)(0)(0)(0)(0)" width=32 stringency=26 */
+	/* pattern="11110,0,1110,0,0,Rn.4,10,(0),0,mask.2,00,SYSm.8" width=32 stringency=18 */
 	{
 		uint32_t instr = req->instr_word32;
 		if(((instr & 0xFFF0D300)==0xF3808000)) {
 			res->instrSize = 32;
-			if(!((instr & 0x20FF)==0x0)) {
+			if(!((instr & 0x2000)==0x0)) {
 				res->flags |= FLAG_UNPREDICTABLE;
 			}
 			if(!(req->arch & ARCH_ARMv6T2) && !(req->arch & ARCH_ARMv7)) {
@@ -12982,6 +12985,9 @@ int msr_reg_app(struct decomp_request *req, struct decomp_result *res)
 			res->fields[FIELD_mask] = (instr & 0xC00)>>10;
 			res->fields_mask[FIELD_mask >> 6] |= 1LL << (FIELD_mask & 63);
 			char mask_width = 2;
+			res->fields[FIELD_SYSm] = instr & 0xFF;
+			res->fields_mask[FIELD_SYSm >> 6] |= 1LL << (FIELD_SYSm & 63);
+			char SYSm_width = 8;
 
 			static const instruction_format instr_formats[] =
 			{
@@ -13027,19 +13033,19 @@ int msr_reg_app(struct decomp_request *req, struct decomp_result *res)
 	return undefined(req, res);
 }
 
-// gen_crc: 0DB01708
+// gen_crc: 90DA8A57
 int msr_reg_sys(struct decomp_request *req, struct decomp_result *res)
 {
 	int rc = -1;
 
 	res->group = INSN_GROUP_UNKNOWN;
 	/* Encoding T1 */
-	/* pattern="11110,0,1110,0,R.1,Rn.4,10,(0),0,mask.4,(0)(0)(0)(0)(0)(0)(0)(0)" width=32 stringency=24 */
+	/* pattern="11110,0,1110,0,R.1,Rn.4,10,(0),0,mask.4,SYSm.8" width=32 stringency=16 */
 	{
 		uint32_t instr = req->instr_word32;
 		if(((instr & 0xFFE0D000)==0xF3808000)) {
 			res->instrSize = 32;
-			if(!((instr & 0x20FF)==0x0)) {
+			if(!((instr & 0x2000)==0x0)) {
 				res->flags |= FLAG_UNPREDICTABLE;
 			}
 			if(!(req->arch & ARCH_ARMv6T2) && !(req->arch & ARCH_ARMv7)) {
@@ -13056,6 +13062,9 @@ int msr_reg_sys(struct decomp_request *req, struct decomp_result *res)
 			res->fields[FIELD_mask] = (instr & 0xF00)>>8;
 			res->fields_mask[FIELD_mask >> 6] |= 1LL << (FIELD_mask & 63);
 			char mask_width = 4;
+			res->fields[FIELD_SYSm] = instr & 0xFF;
+			res->fields_mask[FIELD_SYSm >> 6] |= 1LL << (FIELD_SYSm & 63);
+			char SYSm_width = 8;
 
 			static const instruction_format instr_formats[] =
 			{

--- a/thumb2_disasm/spec.h
+++ b/thumb2_disasm/spec.h
@@ -167,6 +167,7 @@ enum decomp_field {
 	FIELD_round_mode,
 	FIELD_round_nearest,
 	FIELD_round_zero,
+	FIELD_SYSm,
 	FIELD_sat_imm,
 	FIELD_saturate_to,
 	FIELD_set_bigend,

--- a/thumb2_disasm/spec.txt
+++ b/thumb2_disasm/spec.txt
@@ -2012,7 +2012,7 @@ pcode d = UInt(Rd); n = UInt(Rn); lsbit = UInt(imm3:imm2); width = UInt(widthm1)
 msr_reg_app:
 Encoding T1 ARMv6T2, ARMv7
 fmt MSR<c> <spec_reg>,<Rn>
-extract32 11110,0,1110,0,0,Rn.4,10,(0),0,mask.2,00,(0)(0)(0)(0)(0)(0)(0)(0)
+extract32 11110,0,1110,0,0,Rn.4,10,(0),0,mask.2,00,SYSm.8
 pcode_start
 n = UInt(Rn);
 write_nzcvq = (mask<1> == '1');
@@ -2024,7 +2024,7 @@ pcode_end
 msr_reg_sys:
 Encoding T1 ARMv6T2, ARMv7
 fmt MSR<c> <spec_reg>,<Rn>
-extract32 11110,0,1110,0,R.1,Rn.4,10,(0),0,mask.4,(0)(0)(0)(0)(0)(0)(0)(0)
+extract32 11110,0,1110,0,R.1,Rn.4,10,(0),0,mask.4,SYSm.8
 pcode_start
 n = UInt(Rn);
 write_spsr = (R == '1');
@@ -2087,7 +2087,7 @@ pcode n = 14; imm32 = ZeroExtend(imm8, 32); register_form = FALSE; opcode = '001
 mrs:
 Encoding T1 ARMv6T2, ARMv7
 fmt MRS<c> <Rd>,<spec_reg>
-extract32 11110,0,1111,1,R.1,(1)(1)(1)(1),10,(0),0,Rd.4,(0)(0)(0)(0)(0)(0)(0)(0)
+extract32 11110,0,1111,1,R.1,(1)(1)(1)(1),10,(0),0,Rd.4,SYSm.8
 pcode_start
 d = UInt(Rd);
 read_spsr = (R == '1');


### PR DESCRIPTION
ARMv7-[AR] have the SYSm field of MSR/MRS fixed to 0, but ARMv7-M has multiple values which indicate different special registers.

Test cases:
```
eff30980   mrs     r0, psp
80f30988   msr     psp, r0
eff30880   mrs     r0, msp
80f30888   msr     msp, r0
eff30080   mrs     r0, apsr
eff31080   mrs     r0, primask
eff31180   mrs     r0, basepri
eff31380   mrs     r0, faultmask
eff31480   mrs     r0, control
80f30088   msr     apsr_nzcvq, r0
80f31088   msr     primask, r0
80f31188   msr     basepri, r0
80f31388   msr     faultmask, r0
80f31488   msr     control, r0

```