### PR TITLE
Thumb2: Lift BFC instruction

### DIFF
--- a/thumb2_disasm/il_thumb2.cpp
+++ b/thumb2_disasm/il_thumb2.cpp
@@ -554,6 +554,17 @@ bool GetLowLevelILForThumbInstruction(Architecture* arch, LowLevelILFunction& il
 			ConditionalJump(arch, il, instr->fields[FIELD_cond], t, f);
 		}
 		break;
+	case armv7::ARMV7_BFC:
+		{
+			uint32_t lsb = instr->fields[instr->format->operands[1].field0];
+			uint32_t clear_width = instr->fields[instr->format->operands[2].field0];
+			uint32_t mask = ((1 << clear_width) - 1) << lsb;
+			il.AddInstruction(WriteILOperand(il, instr, 0,
+						il.And(4,
+							ReadILOperand(il, instr, 0),
+							il.Const(4, ~mask))));
+		}
+		break;
 	case armv7::ARMV7_BFI:
 	{
 		uint32_t mask;


### PR DESCRIPTION
Other folks have beaten me to most of the stuff I've hit that wasn't lifted, didn't want to miss the boat entirely. :sweat_smile: 

This adds support for lifting the `BFC` Thumb instruction.

![BFC example from firmware](https://user-images.githubusercontent.com/110989/95795567-30704500-0cda-11eb-9162-bc436b5201e7.png)
Lifts into Lifted IL:
![Lifted BFC instruction](https://user-images.githubusercontent.com/110989/95795612-4bdb5000-0cda-11eb-9f1c-92e19d50f968.png)

And the ARMv7-M ARM extract for quick reference:
![Screenshot from 2020-10-12 18-32-07](https://user-images.githubusercontent.com/110989/95795794-cb691f00-0cda-11eb-9c32-ca79c7d2e7e1.png)

