### PR TITLE
ARM: Lift MRC/MCR and friends as intrinsics

### DIFF
--- a/arch_armv7.cpp
+++ b/arch_armv7.cpp
@@ -1310,6 +1310,87 @@ public:
 		return true;
 	}
 
+
+	virtual string GetIntrinsicName(uint32_t intrinsic) override
+	{
+		switch (intrinsic)
+		{
+		case ARMV7_INTRIN_COPROC_GETONEWORD:
+			return "Coproc_GetOneWord";
+		case ARMV7_INTRIN_COPROC_GETTWOWORDS:
+			return "Coproc_GetTwoWords";
+		case ARMV7_INTRIN_COPROC_SENDONEWORD:
+			return "Coproc_SendOneWord";
+		case ARMV7_INTRIN_COPROC_SENDTWOWORDS:
+			return "Coproc_SendTwoWords";
+		default:
+			return "";
+		}
+	}
+
+	virtual vector<uint32_t> GetAllIntrinsics() override
+	{
+		return vector<uint32_t> {
+				ARMV7_INTRIN_COPROC_GETONEWORD,
+				ARMV7_INTRIN_COPROC_GETTWOWORDS,
+				ARMV7_INTRIN_COPROC_SENDONEWORD,
+				ARMV7_INTRIN_COPROC_SENDTWOWORDS,
+		};
+	}
+
+	virtual vector<NameAndType> GetIntrinsicInputs(uint32_t intrinsic) override
+	{
+		switch (intrinsic)
+		{
+		case ARMV7_INTRIN_COPROC_GETONEWORD:
+			return {
+				NameAndType("cp", Type::IntegerType(1, false)),
+				NameAndType(Type::IntegerType(1, false)),
+				NameAndType("n", Type::IntegerType(1, false)),
+				NameAndType("m", Type::IntegerType(1, false)),
+				NameAndType(Type::IntegerType(1, false)),
+			};
+		case ARMV7_INTRIN_COPROC_GETTWOWORDS:
+			return {
+				NameAndType("cp", Type::IntegerType(1, false)),
+				NameAndType(Type::IntegerType(1, false)),
+				NameAndType("m", Type::IntegerType(1, false)),
+			};
+		case ARMV7_INTRIN_COPROC_SENDONEWORD:
+			return {
+				NameAndType(Type::IntegerType(4, false)), 
+				NameAndType("cp", Type::IntegerType(1, false)),
+				NameAndType(Type::IntegerType(1, false)),
+				NameAndType("n", Type::IntegerType(1, false)),
+				NameAndType("m", Type::IntegerType(1, false)),
+				NameAndType(Type::IntegerType(1, false)),
+			};
+		case ARMV7_INTRIN_COPROC_SENDTWOWORDS:
+			return {
+				NameAndType(Type::IntegerType(4, false)),
+				NameAndType(Type::IntegerType(4, false)),
+				NameAndType("cp", Type::IntegerType(1, false)),
+				NameAndType(Type::IntegerType(1, false)),
+				NameAndType("m", Type::IntegerType(1, false)),
+			};
+		default:
+			return vector<NameAndType>();
+		}
+	}
+
+	virtual vector<Confidence<Ref<Type>>> GetIntrinsicOutputs(uint32_t intrinsic) override
+	{
+		switch (intrinsic)
+		{
+		case ARMV7_INTRIN_COPROC_GETONEWORD:
+			return { Type::IntegerType(4, false) };
+		case ARMV7_INTRIN_COPROC_GETTWOWORDS:
+			return { Type::IntegerType(4, false), Type::IntegerType(4, false) };
+		default:
+			return vector<Confidence<Ref<Type>>>();
+		}
+	}
+
 	virtual bool IsNeverBranchPatchAvailable(const uint8_t* data, uint64_t addr, size_t len) override
 	{
 		Instruction instr;

--- a/il.h
+++ b/il.h
@@ -39,6 +39,12 @@ enum Armv7Intrinsic : uint32_t
 	ARMV7_INTRIN_SEV,
 	ARMV7_INTRIN_WFE,
 	ARMV7_INTRIN_WFI,
+	// Following names are from Table D17-2 of ARM DDI 0406C.d, changed  from
+	// CamelCase to UPPERCASE with underscores preserved and ARMV7_INTRIN_ prefixed.
+	ARMV7_INTRIN_COPROC_GETONEWORD, // MRC, MRC2
+	ARMV7_INTRIN_COPROC_GETTWOWORDS, // MRRC, MRRC2
+	ARMV7_INTRIN_COPROC_SENDONEWORD, // MCR, MCR2
+	ARMV7_INTRIN_COPROC_SENDTWOWORDS, // MCRR, MCRR2
 };
 
 bool GetLowLevelILForArmInstruction(BinaryNinja::Architecture* arch, uint64_t addr,


### PR DESCRIPTION
This fixes variable def-use dataflow in low-level code.

![coproc-dataflow](https://user-images.githubusercontent.com/237010/107061161-b08c5000-678c-11eb-9862-e9e3c28cf885.png)

Unlike aarch64 there's no handy `aarch64.SysRegWrite` function with proper arguments. There's just a stub that takes coprocessor # and the whole instruction. Nonetheless:
- Intrinsic names match Reference Manual for easy lookup of semantics.
- Intrinsic arguments are kept minimal to keep HLIL clean, while still providing a clear mapping to actual instruction operands.

At a glance there's no truly common C/C++ intrinsic to copy instead, so it's a choice between matching the  ref. manual or making up something entirely new.