### PR TITLE
Simplify ARMV7_POP instruction

### DIFF
--- a/il.cpp
+++ b/il.cpp
@@ -1130,10 +1130,22 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 			{
 				if (((op1.reg >> j) & 1) == 1)
 				{
-					il.AddInstruction(SetRegisterOrBranch(il, (Register)j,
-						il.Pop(get_register_size((enum Register)j))));
+					if (1 << j == REG_LIST_PC)
+					{
+						il.AddInstruction(
+							il.SetRegister(4, LLIL_TEMP(0),
+								il.Pop(get_register_size((enum Register)j))));
+					}
+					else
+					{
+						il.AddInstruction(SetRegisterOrBranch(il, (Register)j,
+							il.Pop(get_register_size((enum Register)j))));
+					}
+
 				}
 			}
+			if ((op1.reg & REG_LIST_PC) == REG_LIST_PC)
+				il.AddInstruction(il.Jump(il.Register(4, LLIL_TEMP(0))));
 
 			if (CONDITIONAL(instr.cond))
 				il.MarkLabel(falseCode);

--- a/il.cpp
+++ b/il.cpp
@@ -1126,26 +1126,14 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 				il.AddInstruction(il.If(GetCondition(il, instr.cond), trueCode, falseCode));
 				il.MarkLabel(trueCode);
 			}
-			for (int32_t j = 0; j <= 15 << (op1.cls != REG_LIST); j++)
+			for (int32_t j = 0; j <= 15; j++)
 			{
 				if (((op1.reg >> j) & 1) == 1)
 				{
-					if (j == REG_LIST_PC)
-					{
-						il.AddInstruction(
-							il.SetRegister(4, LLIL_TEMP(0),
-								il.Pop(get_register_size((enum Register)j))));
-					}
-					else
-					{
-						il.AddInstruction(SetRegisterOrBranch(il, (Register)j,
-							il.Pop(get_register_size((enum Register)j))));
-					}
-
+					il.AddInstruction(SetRegisterOrBranch(il, (Register)j,
+						il.Pop(get_register_size((enum Register)j))));
 				}
 			}
-			if ((op1.reg & REG_LIST_PC) == REG_LIST_PC)
-				il.AddInstruction(il.Jump(il.Register(4, LLIL_TEMP(0))));
 
 			if (CONDITIONAL(instr.cond))
 				il.MarkLabel(falseCode);


### PR DESCRIPTION
The ARMV7_POP made the assumption that more registers could be used in a pop instruction than possible, and checked for the PC register incorrectly.