### PR TITLE
Add LDA* to operation string table

### DIFF
--- a/armv7_disasm/armv7.c
+++ b/armv7_disasm/armv7.c
@@ -98,6 +98,9 @@ static const char* operationString[] = {
 	"hvc",
 	"isb",
 	"it",
+	"lda",
+	"ldab",
+	"ldah",
 	"ldaex", // A32
 	"ldaexb", // A32
 	"ldaexh", // A32


### PR DESCRIPTION
Mnemonics were wrong due to some missing strings.