### PR TITLE
Add missing thumb2 LLIL lifts for svc, ror(.s)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020-2021 Vector 35 Inc.
+Copyright 2020-2022 Vector 35 Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/arch_armv7.cpp
+++ b/arch_armv7.cpp
@@ -1364,7 +1364,7 @@ public:
 			};
 		case ARMV7_INTRIN_COPROC_SENDONEWORD:
 			return {
-				NameAndType(Type::IntegerType(4, false)), 
+				NameAndType(Type::IntegerType(4, false)),
 				NameAndType("cp", Type::IntegerType(1, false)),
 				NameAndType(Type::IntegerType(1, false)),
 				NameAndType("n", Type::IntegerType(1, false)),
@@ -1691,12 +1691,18 @@ size_t ArmCommonArchitecture::GetFlagWriteLowLevelIL(BNLowLevelILOperation op, s
 
 string ArmCommonArchitecture::GetRegisterName(uint32_t reg)
 {
-	if (reg > REG_Q15)
+	if (reg >= REG_R0 && reg <= REG_Q15)
 	{
-		LogError("Unknown Register: %x - Please report this as a bug.\n", reg);
-		return "unknown";
+		return get_register_name((enum Register)reg);
 	}
-	return get_register_name((enum Register)reg);
+
+	if (reg == FAKEREG_SYSCALL_INFO)
+	{
+		return "syscall_info";
+	}
+
+	LogError("Unknown Register: %x - Please report this as a bug.\n", reg);
+	return "unknown";
 }
 
 vector<uint32_t> ArmCommonArchitecture::GetFullWidthRegisters()
@@ -1724,6 +1730,8 @@ vector<uint32_t> ArmCommonArchitecture::GetAllRegisters()
 		REG_D24,  REG_D25,  REG_D26,  REG_D27,  REG_D28,  REG_D29,  REG_D30,  REG_D31,
 		REG_Q0,   REG_Q1,   REG_Q2,   REG_Q3,   REG_Q4,   REG_Q5,   REG_Q6,   REG_Q7,
 		REG_Q8,   REG_Q9,   REG_Q10,  REG_Q11,  REG_Q12,  REG_Q13,  REG_Q14,  REG_Q15,
+		/* fake registers */
+		FAKEREG_SYSCALL_INFO
 	};
 }
 
@@ -1846,6 +1854,8 @@ BNRegisterInfo ArmCommonArchitecture::GetRegisterInfo(uint32_t reg)
 		case REG_Q14:
 		case REG_Q15:
 			return RegisterInfo(reg, 0, 16);
+		case FAKEREG_SYSCALL_INFO:
+			return RegisterInfo(reg, 0, 4);
 	}
 	return RegisterInfo(0, 0, 0);
 }

--- a/armv7_disasm/armv7.c
+++ b/armv7_disasm/armv7.c
@@ -749,21 +749,21 @@ static const char* endianSpecStrings[] = {
 
 static const char* dsbOptionStrings[] = {
 	"",
+	"oshld", // 1
+	"oshst", // 2
+	"osh",   // 3
 	"",
-	"oshst",
-	"osh",
+	"nshld", // 5
+	"nshst", // 6
+	"nsh",   // 7
 	"",
+	"ishld", // 9
+	"ishst", // 10
+	"ish",   // 11
 	"",
-	"nshst",
-	"nsh",
-	"",
-	"",
-	"ishst",
-	"ish",
-	"",
-	"",
-	"st",
-	"sy",
+	"ld",    // 13
+	"st",    // 14
+	"sy",    // 15
 };
 
 static const char* shiftString[] = {

--- a/armv7_disasm/test.py
+++ b/armv7_disasm/test.py
@@ -1,7 +1,18 @@
 #!/usr/bin/env python
 
+# compile disassembler to ctypes-able shared object:
+# MAC: gcc armv7.c -shared -o disasm.dylib
+
 # (bytes, expected_disassembly, options)
 test_cases = (
+        # supervisor calls
+	(b'\x10\x00\x00\xef', 'svc #0x10', {}),
+	(b'\x00\x00\x00\xef', 'svc #0', {}),
+	(b'\xff\xff\xff\xef', 'svc #0xffffff', {}),
+	(b'\x01\x00\x00\xef', 'svc #0x1', {}),
+	(b'\x02\x00\x00\xef', 'svc #0x2', {}),
+	(b'\x56\x34\x12\xef', 'svc #0x123456', {}),
+        #
 	(b'\x93\xfc\x80\xe1', 'stl r3, [r0]', {}), # NOT 'strex pc, r3, [r0]'
 	(b'\x94\xfc\x81\xe1', 'stl r4, [r1]', {}),
 	(b'\x95\xfc\x82\xe1', 'stl r5, [r2]', {}),
@@ -418,7 +429,7 @@ test_cases = (
 	(b'\x58\x62\x07\xe0', 'and r6, r7, r8, asr r2', {}),
 	(b'\x78\x62\x07\xe0', 'and r6, r7, r8, ror r2', {}),
 	(b'\x66\xa0\x01\xe0', 'and r10, r1, r6, rrx', {}),
-	(b'\x02\x21\xc3\xe3', 'bic r2, r3, #-0x80000000', {}),
+	(b'\x02\x21\xc3\xe3', 'bic r2, r3, #0x80000000', {}),
 	(b'\x0f\x10\x01\xe2', 'and r1, r1, #0xf', {}),
 	(b'\x01\xa0\x0a\xe0', 'and r10, r10, r1', {}),
 	(b'\x01\xa5\x0a\xe0', 'and r10, r10, r1, lsl #0xa', {}),
@@ -1167,9 +1178,6 @@ test_cases = (
 	(b'\x77\x69\x46\xe0', 'sub r6, r6, r7, ror r9', {}),
 	(b'\x22\x30\x41\xe0', 'sub r3, r1, r2, lsr #0x20', {}),
 	(b'\x42\x30\x41\xe0', 'sub r3, r1, r2, asr #0x20', {}),
-	(b'\x10\x00\x00\xef', 'svc #0x10', {}),
-	(b'\x00\x00\x00\xef', 'svc #0', {}),
-	(b'\xff\xff\xff\xef', 'svc #0xffffff', {}),
 	(b'\x92\x10\x03\xe1', 'swp r1, r2, [r3]', {}),
 	(b'\x94\x40\x06\xe1', 'swp r4, r4, [r6]', {}),
 	(b'\x91\x50\x49\xe1', 'swpb r5, r1, [r9]', {}),

--- a/il.cpp
+++ b/il.cpp
@@ -819,9 +819,9 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 						if (op2.reg & 1 << reg)
 						{
 							il.AddInstruction(
-								il.SetRegister(4, 
+								il.SetRegister(4,
 									// writes to PC are deferred to a final Jump
-									(reg != REG_PC) ? reg : LLIL_TEMP(1), 
+									(reg != REG_PC) ? reg : LLIL_TEMP(1),
 									il.Load(4,
 										il.Add(4,
 											il.Register(4, LLIL_TEMP(0)),
@@ -994,9 +994,9 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 		case ARMV7_MCRR2:
 			ConditionExecute(il, instr.cond,
 				il.Intrinsic({ }, ARMV7_INTRIN_COPROC_SENDTWOWORDS,
-					{ 
+					{
 						il.Register(4, op4.reg),
-						il.Register(4, op3.reg), 
+						il.Register(4, op3.reg),
 						il.Const(1, op1.reg),
 						il.Const(1, op2.imm),
 						il.Const(1, op5.reg),
@@ -1059,7 +1059,7 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 						il.AddInstruction(
 							il.Intrinsic(
 								{ RegisterOrFlag::Register(op3.reg) },
-								ARMV7_INTRIN_COPROC_GETONEWORD, 
+								ARMV7_INTRIN_COPROC_GETONEWORD,
 								params
 							)
 						);
@@ -1068,7 +1068,7 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 						il.AddInstruction(
 							il.Intrinsic(
 								{ RegisterOrFlag::Register(LLIL_TEMP(0)) },
-								ARMV7_INTRIN_COPROC_GETONEWORD, 
+								ARMV7_INTRIN_COPROC_GETONEWORD,
 								params
 							)
 						);
@@ -1088,7 +1088,7 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 				il.Intrinsic(
 					{ RegisterOrFlag::Register(op4.reg), RegisterOrFlag::Register(op3.reg) },
 					ARMV7_INTRIN_COPROC_GETTWOWORDS,
-					{ 
+					{
 						il.Const(1, op1.reg),
 						il.Const(1, op2.imm),
 						il.Const(1, op5.reg),
@@ -4293,10 +4293,15 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 							ReadILOperand(il, op3, addr), flagOperation[instr.setsFlags])));
 			break;
 		case ARMV7_SVC:
-			if (op1.cls == IMM && op1.imm == 0)
-				ConditionExecute(il, instr.cond, il.SystemCall());
-			else
-				ConditionExecute(il, instr.cond, il.Undefined());
+			ConditionExecute(addrSize, instr.cond, instr, il,
+					[&](size_t addrSize, Instruction& instr, LowLevelILFunction& il)
+					{
+						(void) addrSize;
+						(void) instr;
+
+						il.AddInstruction(il.SetRegister(4, FAKEREG_SYSCALL_INFO, il.Const(4, op1.imm)));
+						il.AddInstruction(il.SystemCall());
+					});
 			break;
 		case ARMV7_SWP:
 			if (op1.reg == op2.reg)

--- a/il.cpp
+++ b/il.cpp
@@ -4843,6 +4843,32 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 				ConditionExecute(il, instr.cond, SetRegisterOrBranch(il, op1.reg,
 					il.DivUnsigned(get_register_size(op2.reg), ReadRegisterOrPointer(il, op2, addr), ReadRegisterOrPointer(il, op3, addr))));
 			break;
+		case ARMV7_VADD:
+			if((instr.dataType != DT_F32) && (instr.dataType != DT_F32) && (instr.dataType != DT_F64))
+				break;
+
+			ConditionExecute(il, instr.cond,
+				il.SetRegister(get_register_size(op1.reg), op1.reg,
+					il.FloatAdd(get_register_size(op1.reg),
+						il.Register(get_register_size(op2.reg), op2.reg),
+						il.Register(get_register_size(op3.reg), op3.reg)
+					)
+				)
+			);
+			break;
+		case ARMV7_VDIV:
+			if((instr.dataType != DT_F32) && (instr.dataType != DT_F32) && (instr.dataType != DT_F64))
+				break;
+
+			ConditionExecute(il, instr.cond,
+				il.SetRegister(get_register_size(op1.reg), op1.reg,
+					il.FloatDiv(get_register_size(op1.reg),
+						il.Register(get_register_size(op2.reg), op2.reg),
+						il.Register(get_register_size(op3.reg), op3.reg)
+					)
+				)
+			);
+			break;
 		case ARMV7_VLDR:
 			ConditionExecute(addrSize, instr.cond, instr, il,
 					[&](size_t addrSize, Instruction& instr, LowLevelILFunction& il)
@@ -4864,6 +4890,19 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 				ConditionExecute(il, instr.cond, il.Unimplemented());
 			}
 			break;
+		case ARMV7_VMUL:
+			if((instr.dataType != DT_F32) && (instr.dataType != DT_F32) && (instr.dataType != DT_F64))
+				break;
+
+			ConditionExecute(il, instr.cond,
+				il.SetRegister(get_register_size(op1.reg), op1.reg,
+					il.FloatMult(get_register_size(op1.reg),
+						il.Register(get_register_size(op2.reg), op2.reg),
+						il.Register(get_register_size(op3.reg), op3.reg)
+					)
+				)
+			);
+			break;
 		case ARMV7_VSTR:
 			ConditionExecute(addrSize, instr.cond, instr, il,
 					[&](size_t addrSize, Instruction& instr, LowLevelILFunction& il)
@@ -4872,6 +4911,19 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 						(void) instr;
 						Store(il, get_register_size(op2.reg), op1, op2, addr);
 					});
+			break;
+		case ARMV7_VSUB:
+			if((instr.dataType != DT_F32) && (instr.dataType != DT_F32) && (instr.dataType != DT_F64))
+				break;
+
+			ConditionExecute(il, instr.cond,
+				il.SetRegister(get_register_size(op1.reg), op1.reg,
+					il.FloatSub(get_register_size(op1.reg),
+						il.Register(get_register_size(op2.reg), op2.reg),
+						il.Register(get_register_size(op3.reg), op3.reg)
+					)
+				)
+			);
 			break;
 		default:
 			//printf("Instruction: %s\n", get_operation(instr.operation));

--- a/il.h
+++ b/il.h
@@ -51,6 +51,11 @@ enum Armv7Intrinsic : uint32_t
 	ARMV7_INTRIN_SET_EXCLUSIVE_MONITORS,
 };
 
+enum ArmFakeRegister: uint32_t
+{
+	FAKEREG_SYSCALL_INFO = armv7::REG_Q15+1
+};
+
 bool GetLowLevelILForArmInstruction(BinaryNinja::Architecture* arch, uint64_t addr,
     BinaryNinja::LowLevelILFunction& il, armv7::Instruction& instr, size_t addrSize);
 bool GetLowLevelILForThumbInstruction(BinaryNinja::Architecture* arch,

--- a/test_lift.py
+++ b/test_lift.py
@@ -2,6 +2,14 @@
 
 test_cases = \
 [
+    # vadd.f32 s0, s1, s2
+    (b'\x81\x0a\x30\xee', 'LLIL_SET_REG.d(s0,LLIL_FADD.d(LLIL_REG.d(s1),LLIL_REG.d(s2)))'),
+    # vsub.f32 s0, s1, s2
+    (b'\xc1\x0a\x30\xee', 'LLIL_SET_REG.d(s0,LLIL_FSUB.d(LLIL_REG.d(s1),LLIL_REG.d(s2)))'),
+    # vmul.f32 s0, s1, s2
+    (b'\x81\x0a\x20\xee', 'LLIL_SET_REG.d(s0,LLIL_FMUL.d(LLIL_REG.d(s1),LLIL_REG.d(s2)))'),
+    # vdiv.f32 s0, s1, s2
+    (b'\x81\x0a\x80\xee', 'LLIL_SET_REG.d(s0,LLIL_FDIV.d(LLIL_REG.d(s1),LLIL_REG.d(s2)))'),
     # svc #0
     # svc #1
     # svc #2

--- a/test_lift.py
+++ b/test_lift.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+test_cases = \
+[
+    # mov r0, r1
+    (b'\x01\x00\xa0\xe1', 'LLIL_SET_REG.d(r0,LLIL_REG.d(r1))'),
+    # nop
+    (b'\x00\xf0\x20\xe3', 'LLIL_NOP()')
+]
+
+import re
+import sys
+import binaryninja
+from binaryninja import binaryview
+from binaryninja import lowlevelil
+from binaryninja.enums import LowLevelILOperation
+
+def il2str(il):
+    sz_lookup = {1:'.b', 2:'.w', 4:'.d', 8:'.q', 16:'.o'}
+    if isinstance(il, lowlevelil.LowLevelILInstruction):
+        size_code = sz_lookup.get(il.size, '?') if il.size else ''
+        flags_code = '' if not hasattr(il, 'flags') or not il.flags else '{%s}'%il.flags
+
+        # print size-specified IL constants in hex
+        if il.operation in [LowLevelILOperation.LLIL_CONST, LowLevelILOperation.LLIL_CONST_PTR] and il.size:
+            tmp = il.operands[0]
+            if tmp < 0: tmp = (1<<(il.size*8))+tmp
+            tmp = '0x%X' % tmp if il.size else '%d' % il.size
+            return 'LLIL_CONST%s(%s)' % (size_code, tmp)
+        else:
+            return '%s%s%s(%s)' % (il.operation.name, size_code, flags_code, ','.join([il2str(o) for o in il.operands]))
+    elif isinstance(il, list):
+        return '[' + ','.join([il2str(x) for x in il]) + ']'
+    else:
+        return str(il)
+
+# TODO: make this less hacky
+def instr_to_il(data):
+    RETURN = b'\x0e\xf0\xa0\xe1' # mov pc, lr
+    RETURN_LIFTED = 'LLIL_JUMP(LLIL_REG.d(lr))'
+
+    platform = binaryninja.Platform['linux-armv7']
+    # make a pretend function that returns
+    bv = binaryview.BinaryView.new(data + RETURN)
+    bv.add_function(0, plat=platform)
+    assert len(bv.functions) == 1
+
+    result = []
+    #for block in bv.functions[0].low_level_il:
+    for block in bv.functions[0].lifted_il:
+        for il in block:
+            result.append(il2str(il))
+    result = '; '.join(result)
+    # strip return fence
+    if result.endswith(RETURN_LIFTED):
+        result = result[0:result.index(RETURN_LIFTED)]
+    # strip trailing separator
+    if result.endswith('; '):
+        result = result[0:-2]
+
+    return result
+
+def il_str_to_tree(ilstr):
+    result = ''
+    depth = 0
+    for c in ilstr:
+        if c == '(':
+            result += '\n'
+            depth += 1
+            result += '    '*depth
+        elif c == ')':
+            depth -= 1
+        elif c == ',':
+            result += '\n'
+            result += '    '*depth
+            pass
+        else:
+            result += c
+    return result
+
+def test_all():
+    for (test_i, (data, expected)) in enumerate(test_cases):
+        actual = instr_to_il(data)
+        if actual != expected:
+            print('MISMATCH AT TEST %d!' % test_i)
+            print('\t   input: %s' % data.hex())
+            print('\texpected: %s' % expected)
+            print('\t  actual: %s' % actual)
+            print('\t    tree:')
+            print(il_str_to_tree(actual))
+
+            return False
+
+    return True
+
+if __name__ == '__main__':
+    if test_all():
+        print('success!')
+        sys.exit(0)
+    else:
+        sys.exit(-1)
+
+if __name__ == 'test_lift':
+    #if test_all():
+    #    print('success!')
+    pass

--- a/test_lift.py
+++ b/test_lift.py
@@ -2,6 +2,18 @@
 
 test_cases = \
 [
+    # svc #0
+    # svc #1
+    # svc #2
+    # svc #3
+    (b'\x00\x00\x00\xef', 'LLIL_SET_REG.d(syscall_info,LLIL_CONST.d(0x0)); LLIL_SYSCALL()'),
+    (b'\x01\x00\x00\xef', 'LLIL_SET_REG.d(syscall_info,LLIL_CONST.d(0x1)); LLIL_SYSCALL()'),
+    (b'\x02\x00\x00\xef', 'LLIL_SET_REG.d(syscall_info,LLIL_CONST.d(0x2)); LLIL_SYSCALL()'),
+    (b'\x03\x00\x00\xef', 'LLIL_SET_REG.d(syscall_info,LLIL_CONST.d(0x3)); LLIL_SYSCALL()'),
+    # svcle #0xDEAD
+    (b'\xAD\xDE\x00\xdf', 'LLIL_IF(LLIL_FLAG_COND(LowLevelILFlagCondition.LLFC_SLE,None),1,4); LLIL_SET_REG.d(syscall_info,LLIL_CONST.d(0xDEAD)); LLIL_SYSCALL(); LLIL_GOTO(4)'),
+    # svcgt #0xdead
+    (b'\xad\xde\x00\xcf', 'LLIL_IF(LLIL_FLAG_COND(LowLevelILFlagCondition.LLFC_SGT,None),1,4); LLIL_SET_REG.d(syscall_info,LLIL_CONST.d(0xDEAD)); LLIL_SYSCALL(); LLIL_GOTO(4)'),
     # mov r0, r1
     (b'\x01\x00\xa0\xe1', 'LLIL_SET_REG.d(r0,LLIL_REG.d(r1))'),
     # nop

--- a/thumb2_disasm/arch_thumb2.cpp
+++ b/thumb2_disasm/arch_thumb2.cpp
@@ -1453,10 +1453,7 @@ public:
 			uint32_t offset = decomp.instrSize / 8;
 			uint32_t mask = decomp.fields[FIELD_mask];
 			uint32_t cond = decomp.fields[FIELD_firstcond];
-			bool prevCheck = false;
-			bool check;
 			size_t instrCount;
-			LowLevelILLabel thenLabel, elseLabel, doneLabel;
 
 			if (decomp.fields[FIELD_mask] & 1)
 				instrCount = 4;
@@ -1482,36 +1479,16 @@ public:
 
 				il.SetCurrentAddress(this, request.addr);
 
-				check = (i == 0) || (((mask >> (4 - i)) & 1) == (cond & 1));
-				if (prevCheck != check) {
-					/* Emit `if()` if this condition differs from the previous */
+				LowLevelILLabel exec, done;
+				if ((i == 0) || (((mask >> (4 - i)) & 1) == (cond & 1)))
+					SetupThumbConditionalInstructionIL(il, exec, done, cond);
+				else
+					SetupThumbConditionalInstructionIL(il, exec, done, cond ^ 1);
 
-					if (check) {
-						if (i != 0) {
-							il.MarkLabel(doneLabel);
-							doneLabel = LowLevelILLabel();
-						}
-
-						SetupThumbConditionalInstructionIL(il, thenLabel, elseLabel, cond);
-						il.MarkLabel(thenLabel);
-						thenLabel = LowLevelILLabel();
-					} else {
-						if (i != 0)
-							il.AddInstruction(il.Goto(doneLabel));
-
-						il.MarkLabel(elseLabel);
-						elseLabel = LowLevelILLabel();
-					}
-
-					GetLowLevelILForThumbInstruction(this, il, &decomp, true);
-				} else {
-					GetLowLevelILForThumbInstruction(this, il, &decomp, true);
-				}
-				if (i+1 == instrCount) {
-					il.MarkLabel(elseLabel);
-					il.MarkLabel(doneLabel);
-				}
-				prevCheck = check;
+				il.MarkLabel(exec);
+				GetLowLevelILForThumbInstruction(this, il, &decomp, true);
+				il.AddInstruction(il.Goto(done));
+				il.MarkLabel(done);
 			}
 
 			len = offset;
@@ -1599,7 +1576,7 @@ public:
 			*value = (*value & 0b11000111111111111111111111111111) | ((0b111) << 27);
 
 			return true;
-		} 
+		}
 
 		return false;
 	}
@@ -1651,7 +1628,7 @@ public:
 			}
 			*value = (*value & 0b11111111111111111111110000111111) | (cond << 6) ;
 			return true;
-		} 
+		}
 		return false;
 	}
 

--- a/thumb2_disasm/il_thumb2.cpp
+++ b/thumb2_disasm/il_thumb2.cpp
@@ -958,6 +958,14 @@ bool GetLowLevelILForThumbInstruction(Architecture* arch, LowLevelILFunction& il
 		il.AddInstruction(il.SetRegister(2, LLIL_TEMP(1), il.RotateRight(2, il.LogicalShiftRight(2, ReadILOperand(il, instr, 1), il.Const(1, 16)), il.Const(1, 16))));
 		il.AddInstruction(WriteILOperand(il, instr, 0, il.Or(4, il.ShiftLeft(4, il.Register(2, LLIL_TEMP(1)), il.Const(1, 16)), il.Register(2, LLIL_TEMP(0)))));
 		break;
+    case armv7::ARMV7_ROR:
+        il.AddInstruction(WriteArithOperand(il, instr, il.RotateRight(4, ReadArithOperand(il, instr, 0),
+            ReadArithOperand(il, instr, 1), WritesToStatus(instr, ifThenBlock) ? IL_FLAGWRITE_ALL : 0)));
+        break;
+    case armv7::ARMV7_RORS:
+        il.AddInstruction(WriteArithOperand(il, instr, il.RotateRight(4, ReadArithOperand(il, instr, 0),
+            ReadArithOperand(il, instr, 1), ifThenBlock ? 0 : IL_FLAGWRITE_ALL)));
+        break;
 	case armv7::ARMV7_RSB:
 		il.AddInstruction(WriteArithOperand(il, instr, il.Sub(4, ReadArithOperand(il, instr, 1),
 			ReadArithOperand(il, instr, 0), WritesToStatus(instr, ifThenBlock) ? IL_FLAGWRITE_ALL : 0)));
@@ -1111,6 +1119,10 @@ bool GetLowLevelILForThumbInstruction(Architecture* arch, LowLevelILFunction& il
 		il.AddInstruction(WriteArithOperand(il, instr, il.Sub(4, ReadArithOperand(il, instr, 0),
 			ReadArithOperand(il, instr, 1), ifThenBlock ? 0 : IL_FLAGWRITE_ALL)));
 		break;
+    case armv7::ARMV7_SVC:
+        il.AddInstruction(il.SetRegister(4, FAKEREG_SYSCALL_INFO, il.Const(4, instr->fields[instr->format->operands[0].field0])));
+        il.AddInstruction(il.SystemCall());
+        break;
 	case armv7::ARMV7_SXTAB:
 		il.AddInstruction(WriteArithOperand(il, instr, il.Add(4, ReadILOperand(il, instr, 1), il.SignExtend(4, il.LowPart(1, ReadRotatedOperand(il, instr, 2))))));
 		break;


### PR DESCRIPTION
These were missing from `GetLowLevelILForThumbInstruction`, so these instructions would be correctly disassembled but lifted as `unimplemented`.