### PR TITLE
Add vmov immediate lifting

### DIFF
--- a/armv7_disasm/armv7.c
+++ b/armv7_disasm/armv7.c
@@ -839,12 +839,12 @@ uint32_t simdExpandImm(uint32_t op, uint32_t cmode, uint64_t imm8, uint64_t* res
 			 break;
 		case 4:
 			 testImm = 0;
-			 *result = imm8;
+			 *result = (imm8 << 48) | (imm8 << 32) | (imm8 << 16) | imm8;
 			 *dt = DT_I16;
 			 break;
 		case 5:
 			 testImm = 1;
-			 *result = (imm8 << 8);
+			 *result = (imm8 << 56) | (imm8 << 40) | (imm8 << 24) | (imm8 << 8);
 			 *dt = DT_I16;
 			 break;
 		case 6:
@@ -862,7 +862,8 @@ uint32_t simdExpandImm(uint32_t op, uint32_t cmode, uint64_t imm8, uint64_t* res
 				if (op == 0)
 				{
 					*dt = DT_I8;
-					*result = imm8;
+					*result = (imm8 << 56) | (imm8 << 48) | (imm8 << 40) | (imm8 << 32) |
+						(imm8 << 24) | (imm8 << 16) | (imm8 << 8) | imm8;
 				}
 				else
 				{

--- a/il.cpp
+++ b/il.cpp
@@ -4894,6 +4894,20 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 				ConditionExecute(il, instr.cond,
 					SetRegisterOrBranch(il, op1.reg,
 						ReadILOperand(il, op2, addr), flagOperation[instr.setsFlags]));
+			} else if (op1.cls == REG && (op2.cls == IMM || op2.cls == IMM64) && op3.cls == NONE) {
+			/* VMOV(immediate) */
+				if (get_register_size(op1.reg) == 16)
+				{
+					ConditionExecute(il, instr.cond,
+						SetRegisterOrBranch(il, op1.reg,
+							il.Or(16, il.Const(8, op2.imm64), il.ShiftLeft(16, il.Const(8, op2.imm64), il.Const(8, 64))),
+								flagOperation[instr.setsFlags]));
+				} else
+				{
+					ConditionExecute(il, instr.cond,
+						SetRegisterOrBranch(il, op1.reg,
+							il.Const(get_register_size(op1.reg), op2.imm64), flagOperation[instr.setsFlags]));
+				}
 			} else
 			{
 				ConditionExecute(il, instr.cond, il.Unimplemented());

--- a/il.cpp
+++ b/il.cpp
@@ -4932,7 +4932,7 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 					{
 						(void) addrSize;
 						(void) instr;
-						Store(il, get_register_size(op2.reg), op1, op2, addr);
+						Store(il, get_register_size(op1.reg), op1, op2, addr);
 					});
 			break;
 		case ARMV7_VSUB:

--- a/test_lift.py
+++ b/test_lift.py
@@ -34,6 +34,22 @@ test_cases = \
     ('linux-armv7', b'\x01\x00\xa0\xe1', 'LLIL_SET_REG.d(r0,LLIL_REG.d(r1))'),
     # nop
     ('linux-armv7', b'\x00\xf0\x20\xe3', 'LLIL_NOP()'),
+    # vmov.i32 d16, #0
+    ('linux-armv7', b'\x10\x00\xc0\xf2', 'LLIL_SET_REG.q(d16,LLIL_CONST.q(0x0))'),
+    # vmov.i32 q8, #0
+    ('linux-armv7', b'\x50\x00\xc0\xf2', 'LLIL_SET_REG.o(q8,LLIL_OR.o(LLIL_CONST.q(0x0),LLIL_LSL.o(LLIL_CONST.q(0x0),LLIL_CONST.q(0x40))))'),
+    # vmov.i32 d16, #1
+    ('linux-armv7', b'\x11\x00\xc0\xf2', 'LLIL_SET_REG.q(d16,LLIL_CONST.q(0x100000001))'),
+    # vmov.i32 q8, #1
+    ('linux-armv7', b'\x51\x00\xc0\xf2', 'LLIL_SET_REG.o(q8,LLIL_OR.o(LLIL_CONST.q(0x100000001),LLIL_LSL.o(LLIL_CONST.q(0x100000001),LLIL_CONST.q(0x40))))'),
+    # vmov.i16 d16, #0
+    ('linux-armv7', b'\x10\x08\xc0\xf2', 'LLIL_SET_REG.q(d16,LLIL_CONST.q(0x0))'),
+    # vmov.i16 d16, #1
+    ('linux-armv7', b'\x11\x08\xc0\xf2', 'LLIL_SET_REG.q(d16,LLIL_CONST.q(0x1000100010001))'),
+    # vmov.i8 d16, #1
+    ('linux-armv7', b'\x11\x0e\xc0\xf2', 'LLIL_SET_REG.q(d16,LLIL_CONST.q(0x101010101010101))'),
+    # vmov.i8 q8, #1
+    ('linux-armv7', b'\x51\x0e\xc0\xf2', 'LLIL_SET_REG.o(q8,LLIL_OR.o(LLIL_CONST.q(0x101010101010101),LLIL_LSL.o(LLIL_CONST.q(0x101010101010101),LLIL_CONST.q(0x40))))'),
     # mov r2, r0
     ('linux-thumb2', b'\x02\x46', 'LLIL_SET_REG.d(r2,LLIL_REG.d(r0))'),
     # cmp r1, r2

--- a/test_lift.py
+++ b/test_lift.py
@@ -50,6 +50,10 @@ test_cases = \
     ('linux-armv7', b'\x11\x0e\xc0\xf2', 'LLIL_SET_REG.q(d16,LLIL_CONST.q(0x101010101010101))'),
     # vmov.i8 q8, #1
     ('linux-armv7', b'\x51\x0e\xc0\xf2', 'LLIL_SET_REG.o(q8,LLIL_OR.o(LLIL_CONST.q(0x101010101010101),LLIL_LSL.o(LLIL_CONST.q(0x101010101010101),LLIL_CONST.q(0x40))))'),
+    # vstr s0, [r3, #0x8]
+    ('linux-armv7', b'\x02\x0a\x83\xed', 'LLIL_STORE.d(LLIL_ADD.d(LLIL_REG.d(r3),LLIL_CONST.d(0x8)),LLIL_REG.d(s0))'),
+    # vstr d16, [r3, #0x8]
+    ('linux-armv7', b'\x02\x0b\xc3\xed', 'LLIL_STORE.q(LLIL_ADD.d(LLIL_REG.d(r3),LLIL_CONST.d(0x8)),LLIL_REG.q(d16))'),
     # mov r2, r0
     ('linux-thumb2', b'\x02\x46', 'LLIL_SET_REG.d(r2,LLIL_REG.d(r0))'),
     # cmp r1, r2


### PR DESCRIPTION
This PR should properly lift VMOV (immediate) instructions (see A8.8.340 in the ARMv7-A/R Architecture Reference Manual, ARM DDI 0406C.d). Additionally, it fixes a lifting error with VSTR instructions where the wrong register's size was being used to determine storage size.

I'm not wild about the way the constants for 128-bit VMOVs are handled, but it looks like `il.Const` only takes a 64-bit argument, so this seemed the best course. Happy to take a different approach if I've missed anything.

Other instructions that use `simdExpandImm` (VMVN, VBIC, VORR) will need a similar treatment. I'm happy to lift them as well in this PR if requested.